### PR TITLE
feat: add ecr repos

### DIFF
--- a/backend/start_backend.sh
+++ b/backend/start_backend.sh
@@ -70,9 +70,6 @@ echo "Loaded environment variables from $ENV_PATH"
 export ENV_FILE="backend/.${PROFILE}.env"
 export PROFILE
 
-# ---- Build Rust backend ----
-cd "$BACKEND_DIR"
-cargo build
 
 # ---- Kill backend process ----
 APP_PORT="${APP_PORT:=3000}"
@@ -91,6 +88,9 @@ fi
 
 # ---- Start backend as separate process if dev ----
 if [[ "$PROFILE" == "dev" ]]; then
+   # ---- Build Rust backend ----
+    cd "$BACKEND_DIR"
+    cargo build
     cargo run &
     echo "Backend started in development mode"
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,11 @@ services:
   #   profiles: ["dev", "prod"]
 
   life-manager:
+    image: public.ecr.aws/b1a6d4u1/life-manager-backend:latest
     build:
       context: ./backend
       dockerfile: Dockerfile
+    pull_policy: always
     container_name: life_manager_app
     env_file:
       - ${ENV_FILE}
@@ -45,12 +47,14 @@ services:
     profiles: ["prod"]
 
   frontend:
+    image: public.ecr.aws/b1a6d4u1/life-manager-frontend:latest
     build:
       context: ./frontend
       dockerfile: Dockerfile
       target: production
       args:
         EXPO_PUBLIC_API_BASE_URL: ${EXPO_PUBLIC_API_BASE_URL:-https://localhost}
+    pull_policy: always
     container_name: life_manager_frontend
     ports:
       - "${FRONTEND_PORT:-8080}:80"
@@ -58,10 +62,11 @@ services:
     profiles: ["prod"]
 
   gateway:
+    image: public.ecr.aws/b1a6d4u1/life-manager-gateway:latest
     build:
       context: ./nginx
       dockerfile: gateway.Dockerfile
-    image: life-manager-gateway:latest
+    pull_policy: always
     container_name: life_manager_gateway
     profiles: ["prod"]
     env_file:


### PR DESCRIPTION
## Summary

Points the prod Compose stack at **AWS Public ECR** images for the backend, frontend, and gateway (`public.ecr.aws/b1a6d4u1/*`), with **`pull_policy: always`** so deploys prefer fresh published tags. Also restricts **`cargo build`** in `start_backend.sh` to the **dev** profile so test/prod flows no longer compile the Rust backend unnecessarily.

## Problem / context

- Prod services previously relied on local image names / implicit tags only; there was no consistent pull source aligned with published artifacts.
- `start_backend.sh` ran **`cargo build`** for every profile before port cleanup and Compose, adding latency and failing environments where Rust tooling should not run (e.g. test-oriented usage).

## Solution

- **`docker-compose.yml`**: Set `image:` on `life-manager`, `frontend`, and `gateway` to the shared Public ECR repositories and add `pull_policy: always`. Replace the ad hoc gateway image name with the same ECR naming scheme as the other services.
- **`backend/start_backend.sh`**: Move **`cargo build`** (and `cd` into `backend`) inside the **`dev`** branch only, alongside `cargo run`.

## Type of change

- [x] Infrastructure / deployment (Docker Compose, image registry)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation only

## Testing performed

- **CI (current run):** frontend unit tests **passed**; backend unit tests and integration tests **pending** at time of this description update.
- **Local:** not re-run for this PR body update.

## Documentation / follow-ups

- Confirm deploy hosts can reach **Public ECR** (`public.ecr.aws`) and that image tags (`latest` vs pinned SHAs) match release policy.
- If teams build images locally without pushing, document using **`docker compose build`** overrides as needed.
