### PR TITLE
feat: add lets encrypt cert

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-    pull_policy: always
     container_name: life_manager_app
     env_file:
       - ${ENV_FILE}
@@ -51,7 +50,6 @@ services:
       target: production
       args:
         EXPO_PUBLIC_API_BASE_URL: ${EXPO_PUBLIC_API_BASE_URL:-}
-    pull_policy: always
     container_name: life_manager_frontend
     ports:
       - "${FRONTEND_PORT:-8080}:80"
@@ -66,7 +64,6 @@ services:
     build:
       context: ./nginx
       dockerfile: gateway.Dockerfile
-    pull_policy: always
     container_name: life_manager_gateway
     profiles: ["prod"]
     env_file:
@@ -78,6 +75,7 @@ services:
       - "${NGINX_PORT:-80}:80"
       - "443:443"
     volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
       # Writable so the gateway entrypoint can create localhost.crt/key when missing (see nginx/docker-entrypoint.d).
       - ./nginx/certs:/etc/nginx/certs
       - ./nginx/certbot/webroot:/var/www/certbot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,9 @@ services:
     container_name: life_manager_frontend
     ports:
       - "${FRONTEND_PORT:-8080}:80"
+    volumes:
+      # Same host path as gateway: if ACME hits the frontend (e.g. old gateway image), tokens exist and are not served as SPA index.html.
+      - ./nginx/certbot/webroot:/var/www/certbot:ro
     restart: on-failure
     profiles: ["prod"]
 
@@ -78,6 +81,8 @@ services:
       # Writable so the gateway entrypoint can create localhost.crt/key when missing (see nginx/docker-entrypoint.d).
       - ./nginx/certs:/etc/nginx/certs
       - ./nginx/certbot/webroot:/var/www/certbot
+      # Pick up nginx template edits without rebuilding the gateway image.
+      - ./nginx/templates/default.conf.template:/etc/nginx/templates/default.conf.template:ro
     depends_on:
       - life-manager
       - frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
     volumes:
       # Writable so the gateway entrypoint can create localhost.crt/key when missing (see nginx/docker-entrypoint.d).
       - ./nginx/certs:/etc/nginx/certs
+      - ./nginx/certbot/webroot:/var/www/certbot
     depends_on:
       - life-manager
       - frontend

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,8 +8,9 @@ server {
         try_files $uri $uri.html $uri/ /index.html;
     }
 
-    location /.well-known/acme-challenge/ {
+    location ^~ /.well-known/acme-challenge/ {
         root /var/www/certbot;
+        default_type text/plain;
     }
 
 }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,4 +7,9 @@ server {
     location / {
         try_files $uri $uri.html $uri/ /index.html;
     }
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
 }

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -1,16 +1,30 @@
 server {
-    listen 80;
+    listen 80 default_server;
     server_name localhost;
 
-    return 301 https://$host$request_uri;
+    # HTTP-01: serve challenges on plain HTTP; do not redirect this path to HTTPS.
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        default_type text/plain;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }
 
 server {
-    listen 443 ssl;
+    listen 443 ssl default_server;
     server_name localhost;
 
     ssl_certificate /etc/nginx/certs/localhost.crt;
     ssl_certificate_key /etc/nginx/certs/localhost.key;
+
+    # If the CA follows a redirect to HTTPS, still serve the token from the webroot.
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        default_type text/plain;
+    }
 
     location /api {
         proxy_pass http://life-manager:${APP_PORT};

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -1,6 +1,6 @@
 server {
     listen 80 default_server;
-    server_name localhost;
+    server_name life-manager.jeszenka.com;
 
     # HTTP-01: serve challenges on plain HTTP; do not redirect this path to HTTPS.
     location ^~ /.well-known/acme-challenge/ {
@@ -15,10 +15,15 @@ server {
 
 server {
     listen 443 ssl default_server;
-    server_name localhost;
+    server_name life-manager.jeszenka.com;
 
-    ssl_certificate /etc/nginx/certs/localhost.crt;
-    ssl_certificate_key /etc/nginx/certs/localhost.key;
+    ssl_certificate /etc/letsencrypt/live/life-manager.jeszenka.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/life-manager.jeszenka.com/privkey.pem;
+
+    # SSL Settings
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers HIGH:!aNULL:!MD5;
 
     # If the CA follows a redirect to HTTPS, still serve the token from the webroot.
     location ^~ /.well-known/acme-challenge/ {

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -3,7 +3,7 @@ server {
     server_name localhost;
 
     # HTTP-01: serve challenges on plain HTTP; do not redirect this path to HTTPS.
-    location /.well-known/acme-challenge/ {
+    location ^~ /.well-known/acme-challenge/ {
         root /var/www/certbot;
         default_type text/plain;
     }
@@ -21,7 +21,7 @@ server {
     ssl_certificate_key /etc/nginx/certs/localhost.key;
 
     # If the CA follows a redirect to HTTPS, still serve the token from the webroot.
-    location /.well-known/acme-challenge/ {
+    location ^~ /.well-known/acme-challenge/ {
         root /var/www/certbot;
         default_type text/plain;
     }


### PR DESCRIPTION
## Summary

Configures the **prod** gateway and frontend for **Let's Encrypt** on **`life-manager.jeszenka.com`**: mounts host **`/etc/letsencrypt`** and a shared **Certbot webroot**, serves **HTTP-01** challenges without redirecting them to HTTPS, and terminates TLS with the live certificate instead of the previous localhost self-signed pair.

## Problem / context

- The gateway nginx template used **`localhost`** and **self-signed** certs under **`/etc/nginx/certs`**, which does not match a real public hostname or CA-issued certificates.
- A blanket **HTTP → HTTPS** redirect on port 80 breaks **ACME HTTP-01** validation unless **`/.well-known/acme-challenge/`** is served on plain HTTP.
- Without a shared webroot on both gateway and frontend, challenge tokens could be missing or served as the SPA **`index.html`** if traffic hit the frontend container.

## Solution

- **`nginx/templates/default.conf.template`**: set **`server_name`** to **`life-manager.jeszenka.com`**; add **`^~ /.well-known/acme-challenge/`** on ports **80** and **443** (webroot **`/var/www/certbot`**); scope the redirect to **`location /`** only; point **`ssl_certificate`** / **`ssl_certificate_key`** at **`/etc/letsencrypt/live/...`**; add TLS protocol/cipher settings.
- **`docker-compose.yml` (gateway)**: mount **`/etc/letsencrypt`** (read-only), **`./nginx/certbot/webroot`**, and the nginx template for live edits without rebuilding the image; remove **`pull_policy: always`** from prod services.
- **`docker-compose.yml` (frontend)** + **`frontend/nginx.conf`**: mount the same Certbot webroot and serve ACME challenges as plain text so validation works even if requests reach the frontend.

## Type of change

- [x] Feature (production TLS / Let's Encrypt integration)
- [x] Configuration / deployment (Compose volumes, nginx templates)

## Testing performed

- **CI (snapshot when this description was written):** frontend unit tests **passed**; backend unit tests and integration tests **pending** on the latest run for this PR.
- **Local:** not re-run as part of editing this description. Host must have certificates under **`/etc/letsencrypt`** and Certbot webroot content at **`./nginx/certbot/webroot`** before HTTPS will start cleanly.

## Documentation / follow-ups

- Ensure **DNS** for **`life-manager.jeszenka.com`** points at the host and that **Certbot** (or equivalent) can write challenges to **`./nginx/certbot/webroot`** and renew into **`/etc/letsencrypt`** on the host.
- First-time issuance / renewal is outside this PR; document or automate **`certbot certonly`** (or your chosen flow) if not already done on the server.