### PR TITLE
feat: add version endpoint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Write build revision
+        run: ./backend/scripts/write_rev.sh
+
       - name: Run Unit Tests
         run: cargo test --lib --manifest-path backend/Cargo.toml
   integration-tests:
@@ -76,6 +79,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+
+      - name: Write build revision
+        run: ./backend/scripts/write_rev.sh
 
       - name: Run Integration Tests
         run: cd backend && cargo test --test '*'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/*
 backend/target/*
+backend/rev.txt
 node_modules/
 
 # SQLite database files

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,6 +7,8 @@ RUN mkdir src && echo "fn main() {}" > src/main.rs
 RUN cargo build --release
 
 COPY . .
+RUN chmod +x scripts/write_rev.sh \
+ && ./scripts/write_rev.sh
 RUN cargo build --release
 
 # ---- Runtime stage ----
@@ -21,9 +23,10 @@ RUN useradd --system --create-home --shell /usr/sbin/nologin appuser
 WORKDIR /app
 
 COPY --from=builder /app/target/release/life-manager /app/life-manager
+COPY --from=builder /app/rev.txt /app/rev.txt
 
 RUN chmod +x /app/life-manager \
- && chown appuser:appuser /app/life-manager
+ && chown appuser:appuser /app/life-manager /app/rev.txt
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/backend/scripts/write_rev.sh
+++ b/backend/scripts/write_rev.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$BACKEND_DIR/.." && pwd)"
+REV_FILE="$BACKEND_DIR/rev.txt"
+
+if commit="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)"; then
+  printf '%s\n' "$commit" >"$REV_FILE"
+elif [ -s "$REV_FILE" ]; then
+  # Keep rev.txt from the build context (e.g. host wrote it before docker build).
+  exit 0
+else
+  printf 'unknown\n' >"$REV_FILE"
+fi

--- a/backend/src/build_info.rs
+++ b/backend/src/build_info.rs
@@ -1,0 +1,98 @@
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+static GIT_COMMIT: OnceLock<String> = OnceLock::new();
+
+// `CARGO_MANIFEST_DIR` is set by Cargo when compiling this crate (not at runtime).
+// It is the directory containing this package's Cargo.toml (`backend/` locally, `/app`
+// in the Docker builder). `env!` bakes that path into the binary, so we look for
+// `rev.txt` next to the crate root that was built—not from a runtime environment variable.
+fn rev_file_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("rev.txt")
+}
+
+fn load_git_commit_from_file() -> String {
+    let path = rev_file_path();
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            let commit = contents.trim();
+            if commit.is_empty() {
+                tracing::warn!(path = %path.display(), "rev.txt is empty");
+                "unknown".to_string()
+            } else {
+                tracing::info!(path = %path.display(), commit, "Loaded build revision");
+                commit.to_string()
+            }
+        }
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %err,
+                "Could not read rev.txt"
+            );
+            "unknown".to_string()
+        }
+    }
+}
+
+/// Git commit SHA from `rev.txt` (written by `scripts/write_rev.sh` at build/deploy time).
+pub fn git_commit() -> &'static str {
+    GIT_COMMIT.get_or_init(load_git_commit_from_file)
+}
+
+/// Load revision from disk once at startup so missing `rev.txt` is logged early.
+pub fn init() {
+    let _ = git_commit();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn rev_file_path_is_under_manifest_dir() {
+        let path = rev_file_path();
+        assert!(path.ends_with("rev.txt"));
+    }
+
+    #[test]
+    fn load_git_commit_reads_trimmed_rev_file() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let path = rev_file_path();
+        let prior = fs::read_to_string(&path).ok();
+        fs::write(&path, "abc123def456\n\n").unwrap();
+        assert_eq!(load_git_commit_from_file(), "abc123def456");
+        restore_rev_file(&path, prior);
+    }
+
+    #[test]
+    fn load_git_commit_returns_unknown_when_rev_file_missing() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let path = rev_file_path();
+        let prior = fs::read_to_string(&path).ok();
+        let backup = path.with_extension("txt.bak");
+        if path.exists() {
+            fs::rename(&path, &backup).unwrap();
+        }
+        assert_eq!(load_git_commit_from_file(), "unknown");
+        if backup.exists() {
+            fs::rename(&backup, &path).unwrap();
+        }
+        restore_rev_file(&path, prior);
+    }
+
+    fn restore_rev_file(path: &std::path::Path, prior: Option<String>) {
+        match prior {
+            Some(contents) => {
+                fs::write(path, contents).unwrap();
+            }
+            None => {
+                let _ = fs::remove_file(path);
+            }
+        }
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,4 +1,5 @@
 mod application;
+mod build_info;
 mod domain;
 pub mod infrastructure;
 use crate::infrastructure::{
@@ -23,6 +24,7 @@ pub mod schema;
 #[tokio::main]
 pub async fn start_server() {
     tracing::info!("Starting server");
+    build_info::init();
     let app = build_app(None).await;
 
     // Define the address to run the server on
@@ -59,6 +61,7 @@ pub async fn build_app(app_state: Option<AppState>) -> Router {
 
     Router::new()
         .route("/api/health", get(|| async { "up" }))
+        .route("/api/version", get(|| async { build_info::git_commit() }))
         .nest("/api/v1", rest_api_router())
         .layer(
             CorsLayer::new()

--- a/backend/start_backend.sh
+++ b/backend/start_backend.sh
@@ -90,6 +90,7 @@ fi
 if [[ "$PROFILE" == "dev" ]]; then
    # ---- Build Rust backend ----
     cd "$BACKEND_DIR"
+    "$BACKEND_DIR/scripts/write_rev.sh"
     cargo build
     cargo run &
     echo "Backend started in development mode"
@@ -98,6 +99,7 @@ fi
 # --- Build prod images (gateway template must match repo or nginx fails at runtime)
 if [[ "$PROFILE" == "prod" && "$BUILD_IMAGE" -eq 1 ]]; then
   echo "Building Docker images for production..."
+  "$BACKEND_DIR/scripts/write_rev.sh"
   if [[ "$WITH_TESSERACT" -eq 1 ]]; then
     docker compose -f "$COMPOSE_FILE" --env-file "$ENV_PATH" --profile prod --profile tesseract build --no-cache life-manager gateway frontend
   else


### PR DESCRIPTION
## Summary

Adds **`GET /api/version`**, which returns the **full git commit SHA** (plain text) for the revision the backend was built from. The SHA is written to **`backend/rev.txt`** at build/deploy time via **`scripts/write_rev.sh`** and read at runtime from the crate root path baked in at compile time (**`CARGO_MANIFEST_DIR`**).

## Problem / context

- Operators and deploy tooling had no simple way to confirm **which commit** a running backend instance was built from (health only reports **up**).
- Embedding the SHA via compile-time env vars or **`build.rs`** would couple every **`cargo build`** to git and complicate Docker/CI; a small generated file keeps the binary path stable while allowing explicit revision writes where builds actually happen.

## Solution

- **`backend/scripts/write_rev.sh`**: writes **`git rev-parse HEAD`** to **`backend/rev.txt`**, falls back to **`unknown`**, and preserves an existing **`rev.txt`** when git is unavailable (e.g. Docker build context already carried a host-written file).
- **`backend/src/build_info.rs`**: loads and caches the SHA from **`rev.txt`** once at startup; unit tests cover path resolution, trimmed reads, and missing file handling.
- **`backend/src/lib.rs`**: registers **`/api/version`** and calls **`build_info::init()`** on server start.
- **`backend/Dockerfile`**: runs **`write_rev.sh`** before **`cargo build --release`** and copies **`rev.txt`** into the runtime image at **`/app/rev.txt`**.
- **`backend/start_backend.sh`**: invokes **`write_rev.sh`** before **`cargo build`** (dev) and before prod image builds.
- **`.github/workflows/main.yml`**: writes revision before backend unit and integration test jobs.
- **`.gitignore`**: ignores generated **`backend/rev.txt`**.

## Type of change

- [x] Feature (version endpoint for deploy verification)
- [x] Configuration / deployment (build scripts, Dockerfile, CI)

## Testing performed

- **CI (snapshot when this description was written):** frontend unit tests **passed**; backend unit tests and integration tests **pending** on the latest run for this PR.
- **Local:** **`build_info`** unit tests exercise **`rev.txt`** read/trim/missing-file behavior; full stack not re-run as part of editing this description.

## Documentation / follow-ups

- Call **`./backend/scripts/write_rev.sh`** (or rely on **`start_backend.sh`** / Docker / CI) before any **`cargo build`** or test run where **`/api/version`** should reflect the current tree; otherwise the endpoint may report **`unknown`**.
- **`rev.txt`** is gitignored; do not commit it—regenerate per build/deploy.