### PR TITLE
Deploy prod stack to Lightsail after ECR push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,3 +122,43 @@ jobs:
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
 
+  deploy-backend-lightsail:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: deploy-backend-image
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: us-west-2
+      ECR_REGISTRY: 089366939950.dkr.ecr.us-west-2.amazonaws.com
+      DEPLOY_PATH: /home/ec2-user/life-manager
+      GITHUB_SHA: ${{ github.sha }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get ECR login password
+        id: ecr-password
+        run: echo "password=$(aws ecr get-login-password --region "${AWS_REGION}")" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy prod stack on Lightsail
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          ECR_PASSWORD: ${{ steps.ecr-password.outputs.password }}
+          ECR_REGISTRY: ${{ env.ECR_REGISTRY }}
+          DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
+        with:
+          host: ${{ secrets.LIGHTSAIL_HOST }}
+          username: ec2-user
+          key: ${{ secrets.LIGHTSAIL_SSH_PRIVATE_KEY }}
+          port: 22
+          envs: ECR_PASSWORD,ECR_REGISTRY,DEPLOY_PATH,GITHUB_SHA
+          script: |
+            set -euo pipefail
+            cd "${DEPLOY_PATH}"
+            git pull origin main
+            bash scripts/deploy-prod-lightsail.sh
+

--- a/scripts/deploy-prod-lightsail.sh
+++ b/scripts/deploy-prod-lightsail.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Deploy the prod Docker Compose stack on Lightsail after CI pushes images to ECR.
+# Invoked by GitHub Actions over SSH or manually on the instance.
+set -euo pipefail
+
+: "${ECR_PASSWORD:?ECR_PASSWORD is required}"
+: "${ECR_REGISTRY:?ECR_REGISTRY is required}"
+: "${DEPLOY_PATH:?DEPLOY_PATH is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
+ENV_FILE="${ENV_FILE:-backend/.prod.env}"
+COMPOSE_PROFILE="${COMPOSE_PROFILE:-prod}"
+
+echo "${ECR_PASSWORD}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+
+cd "${DEPLOY_PATH}"
+
+echo "Deploying prod stack (:latest images) for commit ${GITHUB_SHA}"
+
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" --profile "${COMPOSE_PROFILE}" pull
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" --profile "${COMPOSE_PROFILE}" up -d
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" --profile "${COMPOSE_PROFILE}" ps


### PR DESCRIPTION
## Summary
- Adds `scripts/deploy-prod-lightsail.sh` to ECR-login, pull all prod compose images, and `up -d` the full prod stack
- Adds `deploy-backend-lightsail` job that SSHs to Lightsail after `deploy-backend-image`, runs `git pull origin main`, then invokes the script

## Prerequisites (already configured)
- `LIGHTSAIL_HOST` and `LIGHTSAIL_SSH_PRIVATE_KEY` repository secrets
- Git clone at `/home/ec2-user/life-manager` with non-interactive `git pull`

## Test plan
- [ ] PR CI passes (deploy jobs skipped on PR)
- [ ] Merge to main; `deploy-backend-image` and `deploy-backend-lightsail` succeed
- [ ] Prod API and gateway respond on Lightsail

Made with [Cursor](https://cursor.com)