### PR TITLE
Fix Lightsail deploy for docker-compose v1

### DIFF
--- a/scripts/deploy-prod-lightsail.sh
+++ b/scripts/deploy-prod-lightsail.sh
@@ -12,12 +12,25 @@ COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
 ENV_FILE="${ENV_FILE:-backend/.prod.env}"
 COMPOSE_PROFILE="${COMPOSE_PROFILE:-prod}"
 
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+else
+  echo "error: neither 'docker compose' nor 'docker-compose' is available" >&2
+  exit 1
+fi
+
+compose() {
+  "${COMPOSE[@]}" -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" --profile "${COMPOSE_PROFILE}" "$@"
+}
+
 echo "${ECR_PASSWORD}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
 
 cd "${DEPLOY_PATH}"
 
 echo "Deploying prod stack (:latest images) for commit ${GITHUB_SHA}"
 
-docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" --profile "${COMPOSE_PROFILE}" pull
-docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" --profile "${COMPOSE_PROFILE}" up -d
-docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" --profile "${COMPOSE_PROFILE}" ps
+compose pull
+compose up -d
+compose ps


### PR DESCRIPTION
## Summary
- `deploy-prod-lightsail.sh` tries `docker compose` first, then `docker-compose`
- Fixes failed main deploy where Lightsail reported `unknown shorthand flag: 'f' in -f`

## Test plan
- [ ] Merge and confirm `deploy-backend-lightsail` succeeds on main

Made with [Cursor](https://cursor.com)